### PR TITLE
Fix changelog link regex

### DIFF
--- a/docs/changelog_and_ci.md
+++ b/docs/changelog_and_ci.md
@@ -10,6 +10,16 @@ This project uses an automated workflow to keep the `CHANGELOG.md` up to date. A
 
 Developers should not manually edit `CHANGELOG.md`; instead, write Conventional Commit messages so the generator can produce clear release notes.
 
+## Changelog Format
+
+Each version header should follow this pattern so automated tests can verify links:
+
+```
+## [1.2.3](https://github.com/<user>/<repo>/releases/tag/v1.2.3) - YYYY-MM-DD
+```
+
+The `tests/test_changelog_links.py` file checks that every entry in `CHANGELOG.md` conforms to this format.
+
 ## Release Workflow
 
 When a new Git tag matching `v[0-9]+\.[0-9]+\.[0-9]+` is pushed to `main`, a separate workflow

--- a/tests/test_changelog_links.py
+++ b/tests/test_changelog_links.py
@@ -4,7 +4,10 @@ from pathlib import Path
 CHANGELOG = Path(__file__).resolve().parents[1] / "CHANGELOG.md"
 
 REPO_URL = "https://github.com/joshuadanpeterson/enhanced-dash-mcp"
-LINK_RE = re.compile(rf"^## \[(\d+\.\d+\.\d+)\]\({REPO_URL}/releases/tag/v\1\) - \d{4}-\d{2}-\d{2}$")
+# Use double braces so f-string doesn't interpret regex quantifiers
+LINK_RE = re.compile(
+    rf"^## \[(\d+\.\d+\.\d+)\]\({REPO_URL}/releases/tag/v\1\) - \d{{4}}-\d{{2}}-\d{{2}}$"
+)
 
 
 def test_changelog_version_links():


### PR DESCRIPTION
## 🚀 Pull Request Overview

### Description

This pull request addresses an issue where the test for verifying changelog links failed due to braces being interpreted by Python f-strings. This fix ensures that the changelog link pattern is parsed correctly by escaping the braces.

### Changes
- [x] Adjusted regex in `tests/test_changelog_links.py` to use double braces
- [x] Documented required changelog format in `docs/changelog_and_ci.md`

### Testing
- [x] `pytest` runs successfully
- [x] Attempted `npm` commands but they failed due to missing `package.json`

### 📺 Demo / Screenshots / GIFs (Optional)



### Related Issues

Closes #<issue_number>

---

## 📋 Checklist

- [x] My code follows the project’s coding style and guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where appropriate
- [x] I have updated or added relevant documentation
- [x] My changes generate no new warnings or errors
- [x] I have added or updated tests as appropriate
- [x] All new and existing tests pass locally

---

## 🧪 Reviewer Testing Notes

Run `pytest` to verify tests pass.

---

## 📑 Additional Context

None


------
https://chatgpt.com/codex/tasks/task_e_68451a3e78bc832083fa0ce22d20c24a