### PR TITLE
Fix changelog link regex

### DIFF
--- a/docs/changelog_and_ci.md
+++ b/docs/changelog_and_ci.md
@@ -10,6 +10,16 @@ This project uses an automated workflow to keep the `CHANGELOG.md` up to date. A
 
 Developers should not manually edit `CHANGELOG.md`; instead, write Conventional Commit messages so the generator can produce clear release notes.
 
+## Changelog Format
+
+Each version header should follow this pattern so automated tests can verify links:
+
+```
+## [1.2.3](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.3) - YYYY-MM-DD
+```
+
+The `tests/test_changelog_links.py` file checks that every entry in `CHANGELOG.md` conforms to this format.
+
 ## Release Workflow
 
 When a new Git tag matching `v[0-9]+\.[0-9]+\.[0-9]+` is pushed to `main`, a separate workflow

--- a/tests/test_changelog_links.py
+++ b/tests/test_changelog_links.py
@@ -4,7 +4,10 @@ from pathlib import Path
 CHANGELOG = Path(__file__).resolve().parents[1] / "CHANGELOG.md"
 
 REPO_URL = "https://github.com/joshuadanpeterson/enhanced-dash-mcp"
-LINK_RE = re.compile(rf"^## \[(\d+\.\d+\.\d+)\]\({REPO_URL}/releases/tag/v\1\) - \d{4}-\d{2}-\d{2}$")
+# Use double braces so f-string doesn't interpret regex quantifiers
+LINK_RE = re.compile(
+    rf"^## \[(\d+\.\d+\.\d+)\]\({REPO_URL}/releases/tag/v\1\) - \d{{4}}-\d{{2}}-\d{{2}}$"
+)
 
 
 def test_changelog_version_links():


### PR DESCRIPTION
## 🚀 Pull Request Overview

### Description

This update clarifies the changelog link format and fixes the test that verifies those links. The regex now escapes braces correctly so Python's f-strings don't misinterpret the pattern.

### Changes

- `tests/test_changelog_links.py` uses double braces in the regex
- Documented the exact changelog link format with the repository URL

### Testing

- ✅ `pytest -q`
- ❌ `npm test` *(failed: missing package.json)*
- ❌ `npm run lint` *(failed: missing package.json)*
- ❌ `npm run type-check` *(failed: missing package.json)*
- ❌ `npm run build` *(failed: missing package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68451a3e78bc832083fa0ce22d20c24a