### PR TITLE
Fix server run with StdioClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enhanced Dash MCP Server
 
-![Version](https://img.shields.io/badge/version-1.1.0-blue.svg)
+![Version](https://img.shields.io/badge/version-1.1.1-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.8+-green.svg)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Platform](https://img.shields.io/badge/platform-macOS-lightgrey.svg)
@@ -421,3 +421,8 @@ MIT License - see [LICENSE](LICENSE) file for details.
 **Built with ❤️ in Fort Collins, CO for developers who value efficient, intelligent documentation access.**
 
 _Transform your development workflow with context-aware documentation that understands your project and coding patterns._
+
+## 📚 Further Reading
+
+- [Changelog and CI](docs/changelog_and_ci.md)
+- [Server Usage](docs/server_usage.md)

--- a/claude-mcp-config.json
+++ b/claude-mcp-config.json
@@ -3,7 +3,7 @@
     "dash-docs": {
       "command": "python3",
       "args": [
-        "~/Dropbox/programming/projects/mcp-servers/enhanced-dash-mcp/enhanced_dash_server.py"
+        "/Users/joshpeterson/Dropbox/programming/projects/mcp-servers/enhanced-dash-mcp/enhanced_dash_server.py"
       ],
       "env": {},
       "description": "Enhanced Dash Documentation Server with project-aware search, fuzzy matching, and content extraction"

--- a/docs/server_usage.md
+++ b/docs/server_usage.md
@@ -12,3 +12,12 @@ python3 enhanced_dash_server.py
 
 This invocation wires the server to STDIO internally and requires no
 additional parameters.
+
+Since version 1.1.1 the main script automatically creates a `StdioClient` and
+passes its streams to `server.run()`. This prevents errors like:
+
+```
+TypeError: Server.run() missing 3 required positional arguments
+```
+
+Just run the script directly and the server will wire itself to STDIO.

--- a/docs/server_usage.md
+++ b/docs/server_usage.md
@@ -1,0 +1,14 @@
+# Running the Enhanced Dash MCP Server
+
+The server communicates over standard input and output. Ensure you run the
+script using the provided `StdioClient` so that MCP clients can connect
+correctly.
+
+Example:
+
+```bash
+python3 enhanced_dash_server.py
+```
+
+This invocation wires the server to STDIO internally and requires no
+additional parameters.

--- a/enhanced_dash_server.py
+++ b/enhanced_dash_server.py
@@ -102,7 +102,7 @@ Author: Josh (Fort Collins, CO)
 Created for integration with Claude via MCP
 Optimized for Python/JavaScript/React development workflows
 """
-__version__ = "1.1.0"  # Project version for SemVer and CHANGELOG automation
+__version__ = "1.1.1"  # Project version for SemVer and CHANGELOG automation
 
 import sqlite3
 import os
@@ -118,6 +118,7 @@ import hashlib
 
 from mcp.server import Server
 from mcp.types import Tool, TextContent
+from mcp.streams import StdioClient  # Used to wire server I/O to STDIO
 from bs4 import BeautifulSoup
 from fuzzywuzzy import fuzz, process
 import aiofiles
@@ -1240,4 +1241,6 @@ async def rate_limited_call_tool(name, arguments):
 
 
 if __name__ == "__main__":
-    asyncio.run(server.run())
+    # Run the server using STDIO streams so MCP clients can communicate
+    client = StdioClient()
+    asyncio.run(server.run(client.read_stream, client.write_stream, {}))

--- a/enhanced_dash_server.py
+++ b/enhanced_dash_server.py
@@ -1241,6 +1241,7 @@ async def rate_limited_call_tool(name, arguments):
 
 
 if __name__ == "__main__":
-    # Run the server using STDIO streams so MCP clients can communicate
+    # Create a StdioClient so Server.run receives the required streams.
+    # This avoids `TypeError` about missing read/write stream arguments.
     client = StdioClient()
     asyncio.run(server.run(client.read_stream, client.write_stream, {}))

--- a/tests/test_main_usage.py
+++ b/tests/test_main_usage.py
@@ -18,7 +18,7 @@ def test_stdio_client_used():
 def test_asyncio_run_invocation():
     """Ensure asyncio.run wraps server.run with all required arguments."""
     content = FILE_PATH.read_text()
-    pattern = re.compile(r"asyncio\.run\(server\.run\(.*client\.read_stream.*client\.write_stream.*{}\)\)")
+    pattern = re.compile(r"asyncio\.run\(server\.run\(.*client\.read_stream.*client\.write_stream.*\{\}\)\)")
     assert pattern.search(content), "asyncio.run invocation malformed"
 
 

--- a/tests/test_main_usage.py
+++ b/tests/test_main_usage.py
@@ -13,3 +13,12 @@ def test_stdio_client_used():
     assert "client.read_stream" in snippet, "read stream not passed"
     assert "client.write_stream" in snippet, "write stream not passed"
 
+
+
+def test_asyncio_run_invocation():
+    """Ensure asyncio.run wraps server.run with all required arguments."""
+    content = FILE_PATH.read_text()
+    pattern = re.compile(r"asyncio\.run\(server\.run\(.*client\.read_stream.*client\.write_stream.*{}\)\)")
+    assert pattern.search(content), "asyncio.run invocation malformed"
+
+

--- a/tests/test_main_usage.py
+++ b/tests/test_main_usage.py
@@ -1,0 +1,15 @@
+import re
+from pathlib import Path
+
+FILE_PATH = Path(__file__).resolve().parents[1] / "enhanced_dash_server.py"
+
+
+def test_stdio_client_used():
+    """Ensure the main section wires the server with StdioClient."""
+    lines = FILE_PATH.read_text().splitlines()
+    snippet = "\n".join(lines[-5:])
+    assert "StdioClient" in snippet, "StdioClient not used"
+    assert "server.run" in snippet, "server.run call missing"
+    assert "client.read_stream" in snippet, "read stream not passed"
+    assert "client.write_stream" in snippet, "write stream not passed"
+

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,4 +10,4 @@ def test_version_constant():
     content = FILE_PATH.read_text()
     match = VERSION_RE.search(content)
     assert match, "__version__ not found"
-    assert match.group(1) == "1.1.0"
+    assert match.group(1) == "1.1.1"

--- a/warp-mcp-config.json
+++ b/warp-mcp-config.json
@@ -13,10 +13,10 @@
   "server": {
     "command": "python3",
     "args": [
-      "~/Dropbox/programming/projects/mcp-servers/enhanced-dash-mcp/enhanced_dash_server.py"
+      "/Users/joshpeterson/Dropbox/programming/projects/mcp-servers/enhanced-dash-mcp/enhanced_dash_server.py"
     ],
     "env": {},
-    "cwd": "~/Dropbox/programming/projects/mcp-servers/enhanced-dash-mcp"
+    "cwd": "/Users/joshpeterson/Dropbox/programming/projects/mcp-servers/enhanced-dash-mcp"
   },
   "tools": [
     {
@@ -218,7 +218,7 @@
     ]
   },
   "development": {
-    "local_path": "~/Dropbox/programming/projects/mcp-servers/enhanced-dash-mcp",
+    "local_path": "/Users/joshpeterson/Dropbox/programming/projects/mcp-servers/enhanced-dash-mcp",
     "environment": "Python virtual environment with dependencies",
     "startup_scripts": ["start-dash-mcp.sh", "start-dash-mcp-tmux.sh"],
     "aliases": [


### PR DESCRIPTION
## 🚀 Pull Request Overview

### Description

This pull request addresses an issue where the MCP server failed to start because `Server.run()` was called without the required streams. The server now initializes a `StdioClient` and passes its streams to `Server.run`.

### Changes
- Updated server entrypoint to use `StdioClient`.
- Corrected file paths in MCP configuration files.
- Bumped version to `1.1.1` and updated README badge.
- Added test coverage for the new entrypoint logic.
- Documented server usage in new help doc.

### Testing
- `npm run lint` *(fails: package.json missing)*
- `npm run type-check` *(fails: package.json missing)*
- `npm run build` *(fails: package.json missing)*
- `npm test` *(fails: package.json missing)*
- `pytest -q` *(passes)*


------
https://chatgpt.com/codex/tasks/task_e_68451dbb600c8320af7607b0f284a6b7