### PR TITLE
Fix StdioClient import error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-#  (2025-06-08)
+# Changelog
 
-
-
+## [1.1.2](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.1.2) - 2025-06-08
+### Fixed
+- use `stdio_server` from MCP library instead of removed `StdioClient`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enhanced Dash MCP Server
 
-![Version](https://img.shields.io/badge/version-1.1.1-blue.svg)
+![Version](https://img.shields.io/badge/version-1.1.2-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.8+-green.svg)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Platform](https://img.shields.io/badge/platform-macOS-lightgrey.svg)

--- a/docs/server_usage.md
+++ b/docs/server_usage.md
@@ -1,7 +1,8 @@
 # Running the Enhanced Dash MCP Server
 
-The server communicates over standard input and output. Ensure you run the
-script using the provided `StdioClient` so that MCP clients can connect
+The server communicates over standard input and output. It uses the
+`stdio_server` context manager from the MCP library to expose its streams
+for MCP clients.
 correctly.
 
 Example:
@@ -13,8 +14,8 @@ python3 enhanced_dash_server.py
 This invocation wires the server to STDIO internally and requires no
 additional parameters.
 
-Since version 1.1.1 the main script automatically creates a `StdioClient` and
-passes its streams to `server.run()`. This prevents errors like:
+Since version 1.1.2 the main script uses `stdio_server` to obtain read and
+write streams for `server.run()`. This prevents errors like:
 
 ```
 TypeError: Server.run() missing 3 required positional arguments

--- a/enhanced_dash_server.py
+++ b/enhanced_dash_server.py
@@ -102,7 +102,7 @@ Author: Josh (Fort Collins, CO)
 Created for integration with Claude via MCP
 Optimized for Python/JavaScript/React development workflows
 """
-__version__ = "1.1.1"  # Project version for SemVer and CHANGELOG automation
+__version__ = "1.1.2"  # Project version for SemVer and CHANGELOG automation
 
 import sqlite3
 import os
@@ -118,7 +118,7 @@ import hashlib
 
 from mcp.server import Server
 from mcp.types import Tool, TextContent
-from mcp.streams import StdioClient  # Used to wire server I/O to STDIO
+from mcp.server.stdio import stdio_server  # Provides STDIO streams for Server.run
 from bs4 import BeautifulSoup
 from fuzzywuzzy import fuzz, process
 import aiofiles
@@ -1240,8 +1240,12 @@ async def rate_limited_call_tool(name, arguments):
     return await call_tool(name, arguments)
 
 
+async def main() -> None:
+    """Run the server with STDIO streams."""
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, {})
+
+
 if __name__ == "__main__":
-    # Create a StdioClient so Server.run receives the required streams.
-    # This avoids `TypeError` about missing read/write stream arguments.
-    client = StdioClient()
-    asyncio.run(server.run(client.read_stream, client.write_stream, {}))
+    # Run the server using asyncio and stdio_server for stream wiring
+    asyncio.run(main())

--- a/tests/test_main_usage.py
+++ b/tests/test_main_usage.py
@@ -4,21 +4,16 @@ from pathlib import Path
 FILE_PATH = Path(__file__).resolve().parents[1] / "enhanced_dash_server.py"
 
 
-def test_stdio_client_used():
-    """Ensure the main section wires the server with StdioClient."""
+def test_stdio_server_used():
+    """Ensure the main section wires the server with stdio_server."""
     lines = FILE_PATH.read_text().splitlines()
-    snippet = "\n".join(lines[-5:])
-    assert "StdioClient" in snippet, "StdioClient not used"
+    snippet = "\n".join(lines[-6:])
+    assert "stdio_server" in snippet, "stdio_server not used"
     assert "server.run" in snippet, "server.run call missing"
-    assert "client.read_stream" in snippet, "read stream not passed"
-    assert "client.write_stream" in snippet, "write stream not passed"
-
 
 
 def test_asyncio_run_invocation():
-    """Ensure asyncio.run wraps server.run with all required arguments."""
+    """Ensure asyncio.run wraps main coroutine."""
     content = FILE_PATH.read_text()
-    pattern = re.compile(r"asyncio\.run\(server\.run\(.*client\.read_stream.*client\.write_stream.*\{\}\)\)")
+    pattern = re.compile(r"asyncio\.run\(main\(\)\)")
     assert pattern.search(content), "asyncio.run invocation malformed"
-
-

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,4 +10,4 @@ def test_version_constant():
     content = FILE_PATH.read_text()
     match = VERSION_RE.search(content)
     assert match, "__version__ not found"
-    assert match.group(1) == "1.1.1"
+    assert match.group(1) == "1.1.2"


### PR DESCRIPTION
## 🚀 Pull Request Overview
### Description
This PR fixes the server startup error due to a missing `mcp.streams.StdioClient`. The script now uses the `stdio_server` context manager from the MCP library.

### Changes
- 🛠️ Replaced `StdioClient` import with `stdio_server`
- 🛠️ Updated main execution to use an async `main` function
- 📝 Updated docs and changelog
- ✅ Updated tests and bumped version to 1.1.2

### Testing
- `npm test` *(fails: package.json missing)*
- `npm run lint` *(fails: package.json missing)*
- `npm run type-check` *(fails: package.json missing)*
- `npm run build` *(fails: package.json missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684527df75c4832091d55e49f664763b