### PR TITLE
Add startup logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.2.2](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.2) - 2025-06-08
+### Added
+- startup and shutdown log messages
+- error logging for unexpected exceptions
+
 ## [1.2.1](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.1) - 2025-06-08
 ### Added
 - startup log message to confirm server launch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-#  (2025-06-08)
+# Changelog
 
-
-
+## [1.2.1](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.1) - 2025-06-08
+### Added
+- startup log message to confirm server launch

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enhanced Dash MCP Server
 
-![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)
+![Version](https://img.shields.io/badge/version-1.2.1-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.8+-green.svg)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Platform](https://img.shields.io/badge/platform-macOS-lightgrey.svg)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enhanced Dash MCP Server
 
-![Version](https://img.shields.io/badge/version-1.2.1-blue.svg)
+![Version](https://img.shields.io/badge/version-1.2.2-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.8+-green.svg)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Platform](https://img.shields.io/badge/platform-macOS-lightgrey.svg)

--- a/docs/help.md
+++ b/docs/help.md
@@ -5,7 +5,7 @@ This project provides an MCP server that interacts with Dash docsets.
 - Run the server with `python3 enhanced_dash_server.py`. The script uses
   `stdio_server` internally to expose STDIO streams. Press `Ctrl+C` to
   stop the server gracefully without seeing a stack trace. Since version
-   1.2.1 the server logs a startup message and cancels its tasks properly so startup no longer hangs
+   1.2.2 the server logs startup, shutdown, and unexpected error events, and cancels its tasks properly so startup no longer hangs
   when interrupted. Cancellation for `Ctrl+C` and task timeouts now
   share a single code path via `_cancel_task`.
 - If you encounter `ModuleNotFoundError: No module named 'mcp.streams'`,
@@ -17,6 +17,6 @@ This project provides an MCP server that interacts with Dash docsets.
 - Logs are written to `~/.cache/dash-mcp/server.log` by default. Adjust
   `DASH_MCP_LOG_LEVEL` and `DASH_MCP_LOG_FILE` environment variables to
   control logging.
-- The log file now includes a startup message so you can verify the server began running.
+- The log file now includes startup and shutdown messages and records any unexpected errors.
 
 For more detailed usage, see [server_usage.md](server_usage.md).

--- a/docs/help.md
+++ b/docs/help.md
@@ -5,7 +5,7 @@ This project provides an MCP server that interacts with Dash docsets.
 - Run the server with `python3 enhanced_dash_server.py`. The script uses
   `stdio_server` internally to expose STDIO streams. Press `Ctrl+C` to
   stop the server gracefully without seeing a stack trace. Since version
-   1.2.0 the server cancels its tasks properly so startup no longer hangs
+   1.2.1 the server logs a startup message and cancels its tasks properly so startup no longer hangs
   when interrupted. Cancellation for `Ctrl+C` and task timeouts now
   share a single code path via `_cancel_task`.
 - If you encounter `ModuleNotFoundError: No module named 'mcp.streams'`,
@@ -17,5 +17,6 @@ This project provides an MCP server that interacts with Dash docsets.
 - Logs are written to `~/.cache/dash-mcp/server.log` by default. Adjust
   `DASH_MCP_LOG_LEVEL` and `DASH_MCP_LOG_FILE` environment variables to
   control logging.
+- The log file now includes a startup message so you can verify the server began running.
 
 For more detailed usage, see [server_usage.md](server_usage.md).

--- a/docs/server_usage.md
+++ b/docs/server_usage.md
@@ -23,8 +23,8 @@ TypeError: Server.run() missing 3 required positional arguments
 
 Just run the script directly and the server will wire itself to STDIO.
 Press `Ctrl+C` to stop the server gracefully; the program handles
-`KeyboardInterrupt` without printing a stack trace. Version 1.2.1 adds a
-startup log message and fixes
+`KeyboardInterrupt` without printing a stack trace. Version 1.2.2 adds startup
+and shutdown log messages and fixes
 an issue where the server could hang during startup when interrupted.
 Both `KeyboardInterrupt` and internal cancellations use the same
 `_cancel_task` helper to ensure consistent cleanup.
@@ -32,4 +32,5 @@ Both `KeyboardInterrupt` and internal cancellations use the same
 Logs are stored in `~/.cache/dash-mcp/server.log` with rotation.
 Set `DASH_MCP_LOG_LEVEL` to control verbosity or `DASH_MCP_LOG_FILE`
 to change the path.
-The log will record a startup message so you can confirm the server launched correctly.
+The log will record startup, shutdown, and unexpected error messages so you can
+confirm the server launched correctly and diagnose failures.

--- a/docs/server_usage.md
+++ b/docs/server_usage.md
@@ -23,7 +23,8 @@ TypeError: Server.run() missing 3 required positional arguments
 
 Just run the script directly and the server will wire itself to STDIO.
 Press `Ctrl+C` to stop the server gracefully; the program handles
-`KeyboardInterrupt` without printing a stack trace. Version 1.2.0 fixes
+`KeyboardInterrupt` without printing a stack trace. Version 1.2.1 adds a
+startup log message and fixes
 an issue where the server could hang during startup when interrupted.
 Both `KeyboardInterrupt` and internal cancellations use the same
 `_cancel_task` helper to ensure consistent cleanup.
@@ -31,3 +32,4 @@ Both `KeyboardInterrupt` and internal cancellations use the same
 Logs are stored in `~/.cache/dash-mcp/server.log` with rotation.
 Set `DASH_MCP_LOG_LEVEL` to control verbosity or `DASH_MCP_LOG_FILE`
 to change the path.
+The log will record a startup message so you can confirm the server launched correctly.

--- a/enhanced_dash_server.py
+++ b/enhanced_dash_server.py
@@ -103,7 +103,8 @@ Created for integration with Claude via MCP
 Optimized for Python/JavaScript/React development workflows
 """
 # Bump version after updating docs and tests to clarify stdio_server usage
-__version__ = "1.2.0"  # Project version for SemVer and CHANGELOG automation
+# Increment version for logging improvements
+__version__ = "1.2.1"  # Project version for SemVer and CHANGELOG automation
 
 import asyncio
 import contextlib
@@ -1276,6 +1277,8 @@ async def _cancel_task(task: asyncio.Task) -> None:
 
 async def main() -> None:
     """Run the server with STDIO streams and handle cancellation."""
+    # Log startup so users know the server is running
+    logger.info("Enhanced Dash MCP server starting (logs: %s)", LOG_FILE)
     async with stdio_server() as (read_stream, write_stream):
         server_task = asyncio.create_task(
             # stdio_server provides untyped streams that satisfy the expected
@@ -1286,6 +1289,9 @@ async def main() -> None:
             await server_task
         except (asyncio.CancelledError, KeyboardInterrupt):
             await _cancel_task(server_task)
+        finally:
+            # Indicate shutdown regardless of cancellation reason
+            logger.info("Enhanced Dash MCP server stopped")
             return
 
 

--- a/enhanced_dash_server.py
+++ b/enhanced_dash_server.py
@@ -103,8 +103,8 @@ Created for integration with Claude via MCP
 Optimized for Python/JavaScript/React development workflows
 """
 # Bump version after updating docs and tests to clarify stdio_server usage
-# Increment version for logging improvements
-__version__ = "1.2.1"  # Project version for SemVer and CHANGELOG automation
+# Increment version for improved error logging
+__version__ = "1.2.2"  # Project version for SemVer and CHANGELOG automation
 
 import asyncio
 import contextlib
@@ -1289,6 +1289,11 @@ async def main() -> None:
             await server_task
         except (asyncio.CancelledError, KeyboardInterrupt):
             await _cancel_task(server_task)
+        except Exception as exc:  # pragma: no cover - sanity
+            # Log unexpected errors to help diagnose failures
+            logger.exception("Error running server: %s", exc)
+            await _cancel_task(server_task)
+            raise
         finally:
             # Indicate shutdown regardless of cancellation reason
             logger.info("Enhanced Dash MCP server stopped")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -93,3 +93,58 @@ async def test_main_logs_startup_message(tmp_path, monkeypatch, stub_modules):
     assert log_file.exists()
     content = log_file.read_text()
     assert "server starting" in content.lower()
+    assert "server stopped" in content.lower()
+
+
+@pytest.mark.asyncio
+async def test_main_logs_error(tmp_path, monkeypatch, stub_modules):
+    """main should log an error when server.run fails."""
+
+    class FailingServer:
+        async def run(self, *_args, **_kwargs) -> None:
+            raise RuntimeError("boom")
+
+        def list_tools(self):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def call_tool(self):
+            def decorator(func):
+                async def wrapper(*args, **kwargs):
+                    return await func(*args, **kwargs)
+
+                return wrapper
+
+            return decorator
+
+    stub_modules["mcp.server"].Server = FailingServer  # type: ignore[attr-defined]
+
+    spec = importlib.util.spec_from_file_location("enhanced_dash_server", MODULE_PATH)
+    assert spec and spec.loader
+    server_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(server_mod)
+
+    log_file = tmp_path / "server.log"
+    server_mod.LOG_FILE = str(log_file)
+    server_mod.configure_logging(logging.INFO, str(log_file))
+
+    async def dummy_stdio_server():
+        class DummyStream:
+            async def send(self, _data: bytes) -> None:
+                pass
+
+            async def receive(self) -> bytes:
+                return b""
+
+        yield DummyStream(), DummyStream()
+
+    monkeypatch.setattr(server_mod, "stdio_server", dummy_stdio_server)
+    monkeypatch.setattr(server_mod, "server", FailingServer())
+
+    with pytest.raises(RuntimeError):
+        await server_mod.main()
+    logging.shutdown()
+    content = log_file.read_text()
+    assert "error running server" in content.lower()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,6 +2,8 @@ import importlib.util
 import logging
 from pathlib import Path
 
+import pytest
+
 MODULE_PATH = Path(__file__).resolve().parents[1] / "enhanced_dash_server.py"
 
 
@@ -37,3 +39,57 @@ def test_configure_logging_creates_file(tmp_path, stub_modules):
     logging.shutdown()
     assert log_file.exists()
     assert "hello" in log_file.read_text()
+
+
+@pytest.mark.asyncio
+async def test_main_logs_startup_message(tmp_path, monkeypatch, stub_modules):
+    """main should record a startup message to the log file."""
+
+    class DummyServer:
+        async def run(self, *_args, **_kwargs) -> None:
+            return
+
+        def list_tools(self):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def call_tool(self):
+            def decorator(func):
+                async def wrapper(*args, **kwargs):
+                    return await func(*args, **kwargs)
+
+                return wrapper
+
+            return decorator
+
+    stub_modules["mcp.server"].Server = DummyServer  # type: ignore[attr-defined]
+
+    spec = importlib.util.spec_from_file_location("enhanced_dash_server", MODULE_PATH)
+    assert spec and spec.loader
+    server_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(server_mod)
+
+    log_file = tmp_path / "server.log"
+    server_mod.LOG_FILE = str(log_file)
+    server_mod.configure_logging(logging.INFO, str(log_file))
+
+    async def dummy_stdio_server():
+        class DummyStream:
+            async def send(self, _data: bytes) -> None:
+                pass
+
+            async def receive(self) -> bytes:
+                return b""
+
+        yield DummyStream(), DummyStream()
+
+    monkeypatch.setattr(server_mod, "stdio_server", dummy_stdio_server)
+    monkeypatch.setattr(server_mod, "server", DummyServer())
+
+    await server_mod.main()
+    logging.shutdown()
+    assert log_file.exists()
+    content = log_file.read_text()
+    assert "server starting" in content.lower()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,4 +10,4 @@ def test_version_constant():
     content = FILE_PATH.read_text()
     match = VERSION_RE.search(content)
     assert match, "__version__ not found"
-    assert match.group(1) == "1.2.1"
+    assert match.group(1) == "1.2.2"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,4 +10,4 @@ def test_version_constant():
     content = FILE_PATH.read_text()
     match = VERSION_RE.search(content)
     assert match, "__version__ not found"
-    assert match.group(1) == "1.2.0"
+    assert match.group(1) == "1.2.1"


### PR DESCRIPTION
## 🚀 Pull Request Overview

### Description
Adds a startup log message so running `python3 enhanced_dash_server.py` immediately writes to the log file and users can confirm the server launched successfully. Documentation references were updated and the version bumped.

### Changes
- log server start/stop in `main`
- bump version to `1.2.1`
- update help docs
- tests verify log creation

### Testing
- `flake8 .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845bae3cbcc83209f02894434a84964