### PR TITLE
Fix initialization options for server startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-#  (2025-06-08)
+# Changelog
+
+## [1.2.3](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.3) - 2025-06-08
+- fix: generate initialization options correctly to avoid AttributeError during startup
 
 
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -8,6 +8,10 @@ This project provides an MCP server that interacts with Dash docsets.
    1.2.2 the server logs startup, shutdown, and unexpected error events, and cancels its tasks properly so startup no longer hangs
   when interrupted. Cancellation for `Ctrl+C` and task timeouts now
   share a single code path via `_cancel_task`.
+- Initialization options are now generated with
+  `server.create_initialization_options()` before running the server to avoid
+  `AttributeError: 'dict' object has no attribute 'capabilities'` in certain MCP
+  clients.
 - If you encounter `ModuleNotFoundError: No module named 'mcp.streams'`,
   update to version 1.1.4 or later which replaces `StdioClient` with
   `stdio_server`.

--- a/docs/server_usage.md
+++ b/docs/server_usage.md
@@ -27,7 +27,10 @@ Press `Ctrl+C` to stop the server gracefully; the program handles
 and shutdown log messages and fixes
 an issue where the server could hang during startup when interrupted.
 Both `KeyboardInterrupt` and internal cancellations use the same
-`_cancel_task` helper to ensure consistent cleanup.
+`_cancel_task` helper to ensure consistent cleanup. The server now calls
+`server.create_initialization_options()` before invoking `server.run()` to
+avoid AttributeError warnings from MCP clients expecting structured
+initialization data.
 
 Logs are stored in `~/.cache/dash-mcp/server.log` with rotation.
 Set `DASH_MCP_LOG_LEVEL` to control verbosity or `DASH_MCP_LOG_FILE`

--- a/enhanced_dash_server.py
+++ b/enhanced_dash_server.py
@@ -104,7 +104,7 @@ Optimized for Python/JavaScript/React development workflows
 """
 # Bump version after updating docs and tests to clarify stdio_server usage
 # Increment version for improved error logging
-__version__ = "1.2.2"  # Project version for SemVer and CHANGELOG automation
+__version__ = "1.2.3"  # Project version for SemVer and CHANGELOG automation
 
 import asyncio
 import contextlib
@@ -1280,10 +1280,11 @@ async def main() -> None:
     # Log startup so users know the server is running
     logger.info("Enhanced Dash MCP server starting (logs: %s)", LOG_FILE)
     async with stdio_server() as (read_stream, write_stream):
+        init_options = server.create_initialization_options()
         server_task = asyncio.create_task(
             # stdio_server provides untyped streams that satisfy the expected
             # asyncio.StreamReader/StreamWriter interface
-            server.run(read_stream, write_stream, {})  # type: ignore[arg-type]
+            server.run(read_stream, write_stream, init_options)
         )
         try:
             await server_task

--- a/tests/test_help_doc.py
+++ b/tests/test_help_doc.py
@@ -6,3 +6,8 @@ HELP_DOC = Path(__file__).resolve().parents[1] / "docs" / "help.md"
 def test_help_mentions_stdio_server():
     content = HELP_DOC.read_text()
     assert "stdio_server" in content
+
+
+def test_help_mentions_initialization_options():
+    content = HELP_DOC.read_text()
+    assert "create_initialization_options" in content

--- a/tests/test_main_usage.py
+++ b/tests/test_main_usage.py
@@ -8,10 +8,11 @@ def test_async_stdio_server_used():
     """Ensure the async main coroutine wires `server.run` with stdio_server."""
     content = FILE_PATH.read_text()
     assert "stdio_server" in content, "stdio_server not referenced"
+    assert "server.create_initialization_options()" in content
     pattern = re.compile(
-        r"server\.run\(\s*read_stream\s*,\s*write_stream\s*,\s*(\{\}|dict\(\))\s*\)"
+        r"server\.run\(\s*read_stream\s*,\s*write_stream\s*,\s*init_options\s*\)"
     )
-    assert pattern.search(content), "server.run call with streams missing or incorrectly formatted"
+    assert pattern.search(content), "server.run call with init_options missing"
 
 
 def test_asyncio_run_invocation():

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,4 +10,4 @@ def test_version_constant():
     content = FILE_PATH.read_text()
     match = VERSION_RE.search(content)
     assert match, "__version__ not found"
-    assert match.group(1) == "1.2.2"
+    assert match.group(1) == "1.2.3"


### PR DESCRIPTION
## 🚀 Pull Request Overview

### Description

This PR resolves a startup warning where the server passed a plain `dict` to `server.run`, leading to an `AttributeError` in MCP clients. The server now uses `server.create_initialization_options()` and passes the returned object when starting.

### Changes
- generate initialization options before calling `server.run`
- document the new initialization step in the help docs
- update usage guide with initialization note
- bump version to 1.2.3 and log entry added
- tests updated/added to reflect initialization options

### Testing
- `flake8 .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845c3211c3483208d115e3fe4eb88e8