### PR TITLE
Fix limit casting bug and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-#  (2025-06-08)
+# Changelog
 
+## [1.2.4](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.4) - 2025-06-08
+- fix: cast limit argument to int to prevent slice index errors
 
-
+## [1.2.3](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.3) - 2025-06-08
+- fix: generate initialization options correctly to avoid AttributeError during startup

--- a/docs/help.md
+++ b/docs/help.md
@@ -18,6 +18,8 @@ This project provides an MCP server that interacts with Dash docsets.
 - Ensure Python 3.8+ and required dependencies from `requirements.txt` are installed.
 - Lint and type-check using `flake8 .` and `mypy .`; configuration files are
   provided in `.flake8` and `mypy.ini`.
+- When calling `search_dash_docs`, pass an integer `limit` between 1 and 100.
+  Values that are not integers will be cast to an integer automatically.
 - Logs are written to `~/.cache/dash-mcp/server.log` by default. Adjust
   `DASH_MCP_LOG_LEVEL` and `DASH_MCP_LOG_FILE` environment variables to
   control logging.

--- a/docs/help.md
+++ b/docs/help.md
@@ -19,7 +19,7 @@ This project provides an MCP server that interacts with Dash docsets.
 - Lint and type-check using `flake8 .` and `mypy .`; configuration files are
   provided in `.flake8` and `mypy.ini`.
 - When calling `search_dash_docs`, pass an integer `limit` between 1 and 100.
-  Values that are not integers will be cast to an integer automatically.
+  Float values are cast to an integer automatically. Non-numeric values raise `ValueError`. Negative numbers are clamped to `1`.
 - Logs are written to `~/.cache/dash-mcp/server.log` by default. Adjust
   `DASH_MCP_LOG_LEVEL` and `DASH_MCP_LOG_FILE` environment variables to
   control logging.

--- a/enhanced_dash_server.py
+++ b/enhanced_dash_server.py
@@ -104,7 +104,7 @@ Optimized for Python/JavaScript/React development workflows
 """
 # Bump version after updating docs and tests to clarify stdio_server usage
 # Increment version for improved error logging
-__version__ = "1.2.3"  # Project version for SemVer and CHANGELOG automation
+__version__ = "1.2.4"  # Project version for SemVer and CHANGELOG automation
 
 import asyncio
 import contextlib
@@ -1042,10 +1042,19 @@ async def call_tool(name, arguments):
             if not arguments.get("query"):
                 raise ValueError("Query parameter is required")
 
+            raw_limit = arguments.get("limit", 20)
+            try:
+                # Cast provided limit to int to avoid slice errors
+                limit = int(float(raw_limit))
+            except (TypeError, ValueError):
+                raise ValueError("limit must be an integer")
+
+            limit = max(1, min(100, limit))  # Enforce limits within range
+
             results = await dash_server.search_docset(
                 query=arguments["query"],
                 docset_name=arguments.get("docset"),
-                limit=max(1, min(100, arguments.get("limit", 20))),  # Enforce limits
+                limit=limit,
                 include_content=arguments.get("include_content", False),
                 use_fuzzy=arguments.get("use_fuzzy", True),
             )

--- a/tests/test_help_doc.py
+++ b/tests/test_help_doc.py
@@ -11,3 +11,8 @@ def test_help_mentions_stdio_server():
 def test_help_mentions_initialization_options():
     content = HELP_DOC.read_text()
     assert "create_initialization_options" in content
+
+
+def test_help_mentions_limit_validation():
+    content = HELP_DOC.read_text()
+    assert "integer `limit`" in content

--- a/tests/test_search_limit.py
+++ b/tests/test_search_limit.py
@@ -43,3 +43,45 @@ async def test_search_limit_casts_to_int(monkeypatch, stub_modules):
 
     await server_mod.call_tool("search_dash_docs", {"query": "pip", "limit": 5.0})
     assert isinstance(captured['limit'], int)
+
+
+@pytest.mark.asyncio
+async def test_search_limit_string_raises(monkeypatch, stub_modules):
+    """Non-numeric limit values should raise a ValueError."""
+    stub_modules["mcp.server"].Server = DummyServer  # type: ignore[attr-defined]
+    spec = importlib.util.spec_from_file_location("enhanced_dash_server", MODULE_PATH)
+    assert spec and spec.loader
+    server_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(server_mod)
+
+    async def fake_search_docset(**_kwargs):
+        return []
+
+    monkeypatch.setattr(server_mod.dash_server, "search_docset", fake_search_docset)
+
+    with pytest.raises(ValueError, match="limit must be an integer"):
+        await server_mod.call_tool(
+            "search_dash_docs",
+            {"query": "pip", "limit": "bad"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_limit_negative_clamped(monkeypatch, stub_modules):
+    """Negative limit values are clamped to one."""
+    stub_modules["mcp.server"].Server = DummyServer  # type: ignore[attr-defined]
+    spec = importlib.util.spec_from_file_location("enhanced_dash_server", MODULE_PATH)
+    assert spec and spec.loader
+    server_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(server_mod)
+
+    captured = {}
+
+    async def fake_search_docset(*, query, docset_name=None, limit=20, include_content=False, use_fuzzy=True):
+        captured['limit'] = limit
+        return []
+
+    monkeypatch.setattr(server_mod.dash_server, "search_docset", fake_search_docset)
+
+    await server_mod.call_tool("search_dash_docs", {"query": "pip", "limit": -10})
+    assert captured['limit'] == 1

--- a/tests/test_search_limit.py
+++ b/tests/test_search_limit.py
@@ -1,0 +1,45 @@
+import importlib.util
+import pytest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "enhanced_dash_server.py"
+
+
+class DummyServer:
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    def list_tools(self):
+        def decorator(func):
+            return func
+        return decorator
+
+    def call_tool(self):
+        def decorator(func):
+            async def wrapper(*args, **kwargs):
+                return await func(*args, **kwargs)
+            return wrapper
+        return decorator
+
+    async def run(self, *_args, **_kwargs):  # pragma: no cover - stub
+        pass
+
+
+@pytest.mark.asyncio
+async def test_search_limit_casts_to_int(monkeypatch, stub_modules):
+    stub_modules["mcp.server"].Server = DummyServer  # type: ignore[attr-defined]
+    spec = importlib.util.spec_from_file_location("enhanced_dash_server", MODULE_PATH)
+    assert spec and spec.loader
+    server_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(server_mod)
+
+    captured = {}
+
+    async def fake_search_docset(*, query, docset_name=None, limit=20, include_content=False, use_fuzzy=True):
+        captured['limit'] = limit
+        return []
+
+    monkeypatch.setattr(server_mod.dash_server, "search_docset", fake_search_docset)
+
+    await server_mod.call_tool("search_dash_docs", {"query": "pip", "limit": 5.0})
+    assert isinstance(captured['limit'], int)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,4 +10,4 @@ def test_version_constant():
     content = FILE_PATH.read_text()
     match = VERSION_RE.search(content)
     assert match, "__version__ not found"
-    assert match.group(1) == "1.2.3"
+    assert match.group(1) == "1.2.4"


### PR DESCRIPTION
## 🚀 Pull Request Overview

### Description
This pull request fixes a bug where passing a float `limit` to `search_dash_docs` resulted in a slice error. The limit is now cast to an integer and validated. Documentation and tests were updated accordingly.

### Changes
- 🐛 Cast the `limit` argument to an integer before calling `search_docset`.
- 📝 Document integer limits for the search tool in `help.md`.
- ✅ Add regression test ensuring `limit` casting and update version test.
- 📝 Update changelog with v1.2.4 entry.

### Testing
- `flake8 .`
- `mypy --install-types --non-interactive .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845cbbdfd6883208fbb16459357b239