### PR TITLE
feat: Allow nested docset directories

### DIFF
--- a/enhanced_dash_server.py
+++ b/enhanced_dash_server.py
@@ -385,7 +385,7 @@ class DashMCPServer:
             return cached
 
         docsets = []
-        for docset_dir in self.docsets_path.glob("*.docset"):
+        for docset_dir in self.docsets_path.glob("**/*.docset"):
             db_path = docset_dir / "Contents/Resources/docSet.dsidx"
             docs_path = docset_dir / "Contents/Resources/Documents"
 


### PR DESCRIPTION
Updates the glob pattern in get_available_docsets function to recursively search for .docset directories. This enables the server to find docsets located in subfolders within the docsets path.

This change fixes empty docsets found in DocSets Dir of Dash 4.

```bash
 ~/Library/Application Support/Dash/DocSets ❯ tree -N -L 2                                                                                                            
.
├── Bash
│   └── Bash.docset
├── C
│   └── C.docset
├── C++
│   └── C++.docset
├── CMake
│   └── CMake.docset
├── Common_Lisp
│   └── Common Lisp.docset
├── Erlang
│   └── Erlang.docset
├── JavaScript
│   └── JavaScript.docset
├── LaTeX
│   └── LaTeX.docset
```