### PR TITLE
Fix changelog workflow to preserve history

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # ensure full history so changelog isn't truncated
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
-#  (2025-06-08)
+# Changelog
+## [1.2.11](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.11) - 2025-06-10
+- feat: recursively search for `.docset` directories to support nested docsets
+
+## [1.2.10](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.10) - 2025-06-10
+- docs: clarify symlink placement instructions in README
+## [1.2.9](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.9) - 2025-06-08
+- fix: preserve full history when generating changelog via GitHub Actions
+## [1.2.8](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.8) - 2025-06-08
+- fix: handle symlinked DocSets paths more robustly
+- test: add coverage for symlinked DocSets environment variable
+
+## [1.2.7](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.7) - 2025-06-08
+- feat: automatically adjust docset path when DASH_DOCSETS_PATH points to Dash directory or symlink
 
 
+## [1.2.6](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.6) - 2025-06-08
+- feat: log docset directory on startup and resolve symlinks
 
+## [1.2.5](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.5) - 2025-06-08
+- feat: docset directory can be configured via `DASH_DOCSETS_PATH`
+
+## [1.2.4](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.4) - 2025-06-08
+- fix: cast limit argument to int to prevent slice index errors
+
+## [1.2.3](https://github.com/joshuadanpeterson/enhanced-dash-mcp/releases/tag/v1.2.3) - 2025-06-08
+- fix: generate initialization options correctly to avoid AttributeError during startup

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enhanced Dash MCP Server
 
-![Version](https://img.shields.io/badge/version-1.2.8-blue.svg)
+![Version](https://img.shields.io/badge/version-1.2.11-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.8+-green.svg)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Platform](https://img.shields.io/badge/platform-macOS-lightgrey.svg)

--- a/docs/help.md
+++ b/docs/help.md
@@ -5,7 +5,7 @@ This project provides an MCP server that interacts with Dash docsets.
 - Run the server with `python3 enhanced_dash_server.py`. The script uses
   `stdio_server` internally to expose STDIO streams. Press `Ctrl+C` to
   stop the server gracefully without seeing a stack trace. Since version
-   1.2.8 the server logs startup, shutdown, and unexpected error events, and cancels its tasks properly so startup no longer hangs
+  1.2.11 the server logs startup, shutdown, and unexpected error events, and cancels its tasks properly so startup no longer hangs
   when interrupted. Cancellation for `Ctrl+C` and task timeouts now
   share a single code path via `_cancel_task`.
 - Initialization options are now generated with
@@ -31,8 +31,11 @@ This project provides an MCP server that interacts with Dash docsets.
   path like `.../DocSets/DocSets` and the server won't find your docsets.
 - The server now adjusts automatically if `DASH_DOCSETS_PATH` points to the
   `Dash` directory instead of `DocSets`.
+- Docsets inside subfolders are discovered automatically so Dash 4 layouts work
+  without extra configuration.
 - The log file now includes startup and shutdown messages and records any unexpected errors.
 
 - Review [CHANGELOG.md](../CHANGELOG.md) for a summary of recent releases.
 
 For more detailed usage, see [server_usage.md](server_usage.md).
+- The changelog is automatically updated by GitHub Actions. The workflow now fetches full history so older entries stay intact.

--- a/docs/server_usage.md
+++ b/docs/server_usage.md
@@ -23,7 +23,7 @@ TypeError: Server.run() missing 3 required positional arguments
 
 Just run the script directly and the server will wire itself to STDIO.
 Press `Ctrl+C` to stop the server gracefully; the program handles
-`KeyboardInterrupt` without printing a stack trace. Version 1.2.8 adds startup
+`KeyboardInterrupt` without printing a stack trace. Version 1.2.11 adds startup
 and shutdown log messages and fixes
 an issue where the server could hang during startup when interrupted.
 Both `KeyboardInterrupt` and internal cancellations use the same
@@ -39,5 +39,7 @@ Set `DASH_DOCSETS_PATH` only if your Dash documentation lives outside the defaul
 Symlinks under `~/Library/Application Support/Dash` are followed automatically.
 If the variable points at the `Dash` directory rather than `DocSets`, the server
 will automatically correct the search path.
+Docsets stored in subfolders are detected as well, enabling support for Dash 4's
+layout where docsets can be nested within categories.
 The log will record startup, shutdown, and unexpected error messages so you can
 confirm the server launched correctly and diagnose failures.

--- a/enhanced_dash_server.py
+++ b/enhanced_dash_server.py
@@ -104,7 +104,7 @@ Optimized for Python/JavaScript/React development workflows
 """
 # Bump version after updating docs and tests to clarify stdio_server usage
 # Increment version for improved error logging
-__version__ = "1.2.8"  # Project version for SemVer and CHANGELOG automation
+__version__ = "1.2.11"  # Project version for SemVer and CHANGELOG automation
 
 import asyncio
 import contextlib
@@ -385,7 +385,8 @@ class DashMCPServer:
             return cached
 
         docsets = []
-        for docset_dir in self.docsets_path.glob("*.docset"):
+        # Search recursively so docsets in subfolders are discovered (Dash 4 layout)
+        for docset_dir in self.docsets_path.rglob("*.docset"):
             db_path = docset_dir / "Contents/Resources/docSet.dsidx"
             docs_path = docset_dir / "Contents/Resources/Documents"
 

--- a/tests/test_changelog_history.py
+++ b/tests/test_changelog_history.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+CHANGELOG = Path(__file__).resolve().parents[1] / "CHANGELOG.md"
+
+
+def test_changelog_preserves_history():
+    content = CHANGELOG.read_text()
+    assert "1.2.9" in content, "Previous changelog entries missing"

--- a/tests/test_nested_docsets.py
+++ b/tests/test_nested_docsets.py
@@ -1,0 +1,51 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "enhanced_dash_server.py"
+
+
+class DummyServer:
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def list_tools(self) -> Any:
+        def decorator(func: Any) -> Any:
+            return func
+        return decorator
+
+    def call_tool(self) -> Any:
+        def decorator(func: Any) -> Any:
+            async def wrapper(*args: Any, **kwargs: Any) -> Any:
+                return await func(*args, **kwargs)
+            return wrapper
+        return decorator
+
+    async def run(self, *_args: Any, **_kwargs: Any) -> None:  # pragma: no cover
+        pass
+
+
+@pytest.mark.asyncio
+async def test_nested_docset_detection(monkeypatch, tmp_path, stub_modules) -> None:
+    """Docsets located in subfolders should be detected."""
+    stub_modules["mcp.server"].Server = DummyServer  # type: ignore[attr-defined]
+
+    # create nested docset path
+    nested = tmp_path / "DocSets" / "Languages" / "Go.docset" / "Contents" / "Resources"
+    nested.mkdir(parents=True)
+    (nested / "docSet.dsidx").write_text("")
+
+    monkeypatch.setenv("DASH_DOCSETS_PATH", str(tmp_path / "DocSets"))
+
+    spec = importlib.util.spec_from_file_location("enhanced_dash_server", MODULE_PATH)
+    assert spec and spec.loader
+    server_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(server_mod)
+
+    dash_server = server_mod.DashMCPServer()
+    docsets = await dash_server.get_available_docsets()
+    names = {d["name"] for d in docsets}
+    assert "Go" in names

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,4 +10,4 @@ def test_version_constant():
     content = FILE_PATH.read_text()
     match = VERSION_RE.search(content)
     assert match, "__version__ not found"
-    assert match.group(1) == "1.2.8"
+    assert match.group(1) == "1.2.11"


### PR DESCRIPTION
## 🚀 Pull Request Overview

### Description

Adds support for docsets stored in nested directories and bumps the project to version `1.2.11`. Documentation now notes that GitHub Actions fetches the full history before generating the changelog so earlier entries remain intact.

### Changes
- recursively search for `.docset` folders
- document subfolder support and update version references
- add regression test for nested docsets detection

### Testing
- `flake8 .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847cba9b6288320822087ad84430405